### PR TITLE
CLI can now chat safely one chat per session or two chats to the same peer if once it initiates and the other time it receives.

### DIFF
--- a/src/app/app.c
+++ b/src/app/app.c
@@ -187,7 +187,7 @@ int app_code_for_command_with_param(char *command, jnx_size cmd_len, char **opar
   } else {
     retval = code_for_command(raw_cmd);
   }
-//  free(command);
+  free(command);
   return retval;
 }
 

--- a/src/app/app.c
+++ b/src/app/app.c
@@ -116,8 +116,10 @@ void app_create_gui_session(session *s, session_service *serv) {
   pair_session_with_gui(s, (void *) c);
   jnx_thread_create_disposable(read_user_input_loop, (void *) c);
   jnx_char *message;
-  while (0 < session_message_read(s,(jnx_uint8 **) &message)) {
-    gui_receive_message(c, message);
+  while (c->is_active) {
+    if (0 < session_message_read(s, (jnx_uint8 **) &message)) {
+      gui_receive_message(c, message);
+    }
   }
   unpair_session_from_gui(s, (void *) c);
 }

--- a/src/app/app.c
+++ b/src/app/app.c
@@ -187,7 +187,7 @@ int app_code_for_command_with_param(char *command, jnx_size cmd_len, char **opar
   } else {
     retval = code_for_command(raw_cmd);
   }
-  free(command);
+//  free(command);
   return retval;
 }
 

--- a/src/app/app.c
+++ b/src/app/app.c
@@ -53,7 +53,7 @@ static int get_session_interaction_path(char *path) {
   return get_tmp_path(path, SESSION_INTERACTION);
 }
 
-static int get_recieve_guid_path(char *path) {
+static int get_receive_guid_path(char *path) {
   return get_tmp_path(path, RECEIVE_GUID);
 }
 
@@ -79,7 +79,7 @@ int app_accept_or_reject_session(discovery_service *ds,
                                  jnx_guid *initiator_guid, jnx_guid *session_guid) {
   char sockpath[128], guidpath[128];
   get_session_interaction_path(sockpath);
-  get_recieve_guid_path(guidpath);
+  get_receive_guid_path(guidpath);
   unlink(sockpath);
   unlink(guidpath);
   jnx_unix_socket *s = jnx_unix_stream_socket_create(sockpath),
@@ -88,14 +88,16 @@ int app_accept_or_reject_session(discovery_service *ds,
   peer *p = peerstore_lookup(ds->peers, initiator_guid);
   printf("You have a chat request from %s. %s",
          p->user_name, "Would you like to accept or reject the chat? [a/r]: ");
-  accept_reject_dto ar;
   fflush(stdout);
+
+  accept_reject_dto ar;
   ar.session_guid = session_guid;
   jnx_unix_stream_socket_listen_with_context(
       s, 1, user_accept_reject, (void *) &ar);
   jnx_unix_stream_socket_send(gs, (void *) session_guid, sizeof(jnx_guid));
   jnx_unix_socket_destroy(&gs);
   jnx_unix_socket_destroy(&s);
+
   return ar.abort;
 }
 
@@ -385,7 +387,7 @@ static jnx_int32 read_guid(jnx_uint8 *buffer, jnx_size bytesread,
 session *app_accept_chat(app_context_t *context) {
   char sockpath[128], guidpath[128];
   get_session_interaction_path(sockpath);
-  get_recieve_guid_path(guidpath);
+  get_receive_guid_path(guidpath);
   jnx_unix_socket *us = jnx_unix_stream_socket_create(sockpath),
       *gs = jnx_unix_stream_socket_create(guidpath);
   jnx_unix_stream_socket_send(us, (jnx_uint8 *) "accept",

--- a/src/app/app.c
+++ b/src/app/app.c
@@ -334,6 +334,7 @@ int link_session_protocol(session *s, linked_session_type lst, void *optarg) {
 
 int unlink_session_protocol(session *s, linked_session_type stype, void *optargs) {
   app_context_t *context = optargs;
+  printf("---------- unlink session protocol ----------- \n");
   auth_comms_stop(context->auth_comms,s);
   return 0;
 }

--- a/src/app/app.c
+++ b/src/app/app.c
@@ -186,9 +186,11 @@ int app_code_for_command_with_param(char *command, jnx_size cmd_len, char **opar
       printf("Requires name of peer as argument.\n");
       retval = CMD_HELP;
     }
-    *oparam = malloc(strlen(extra_params) + 1);
-    strcpy(*oparam, extra_params);
-    return CMD_SESSION;
+    else {
+      *oparam = malloc(strlen(extra_params) + 1);
+      strcpy(*oparam, extra_params);
+      retval = CMD_SESSION;
+    }
   } else {
     retval = code_for_command(raw_cmd);
   }

--- a/src/app/app.c
+++ b/src/app/app.c
@@ -109,7 +109,7 @@ void unpair_session_from_gui(void *gui_context) {
   session_state r = session_service_unlink_sessions(
       act->session_serv,
       E_AM_RECEIVER,
-      NULL,
+      act,
       &context->s->session_guid);
 
   JNXCHECK(r == SESSION_STATE_OKAY);

--- a/src/app/app.c
+++ b/src/app/app.c
@@ -137,8 +137,8 @@ void app_create_gui_session(session *s, app_context_t *app_context) {
   while (0 < session_message_read(s, (jnx_uint8 **) &message)) {
     gui_receive_message(gc, message);
   }
-  if (QUIT_LOCAL != gc->quit_peer) {
-    gc->quit_peer = QUIT_REMOTE;
+  if (QUIT_NONE == gc->quit_hint) {
+    gc->quit_hint = QUIT_ON_NEXT_USER_INPUT;
   }
   // wait for user input thread to complete
   pthread_join(user_input_thread->system_thread, NULL);

--- a/src/app/app.c
+++ b/src/app/app.c
@@ -131,11 +131,8 @@ void app_create_gui_session(session *s, app_context_t *app_context) {
   session_service *serv = app_context->session_serv;
   gui_context_t *gc = gui_create(s, serv);
   pair_session_with_gui(s, (void *) gc, (void *) app_context);
-
   jnx_thread *user_input_thread =
       jnx_thread_create(read_user_input_loop, (void *) gc);
-  print_pthread_t(user_input_thread->system_thread);
-
   jnx_char *message;
   while (0 < session_message_read(s, (jnx_uint8 **) &message)) {
     gui_receive_message(gc, message);
@@ -143,6 +140,7 @@ void app_create_gui_session(session *s, app_context_t *app_context) {
   if (QUIT_LOCAL != gc->quit_peer) {
     gc->quit_peer = QUIT_REMOTE;
   }
+  // wait for user input thread to complete
   pthread_join(user_input_thread->system_thread, NULL);
 }
 

--- a/src/app/app.c
+++ b/src/app/app.c
@@ -102,9 +102,12 @@ int app_accept_or_reject_session(discovery_service *ds,
 }
 
 void unpair_session_from_gui(void *gui_context) {
-  printf("[DEBUG] Unpairing session from GUI...\n");
   gui_context_t *context = (gui_context_t *)gui_context;
   app_context_t *act = (app_context_t *) context->args;
+  char *guid;
+  jnx_guid_to_string(&context->s->session_guid, &guid);
+  printf("[DEBUG] Unpairing GUI from session '%s'...\n", guid);
+
   context->is_active = 0;
   printf("Exiting GUI from accept.\n");
   session_state r = session_service_unlink_sessions(
@@ -120,6 +123,9 @@ void unpair_session_from_gui(void *gui_context) {
 }
 
 void pair_session_with_gui(session *s, void *gui_context, void *app_context) {
+  char *guid;
+  jnx_guid_to_string(&s->session_guid, &guid);
+  printf("[DEBUG] Pairing GUI with session '%s'...", guid);
   s->gui_context = gui_context;
   gui_context_t *gc = (gui_context_t *) gui_context;
 

--- a/src/app/app.c
+++ b/src/app/app.c
@@ -27,6 +27,7 @@
 #include "../gui/gui.h"
 #include "auth_comms.h"
 #include "port_control.h"
+#include <unistd.h>
 
 #define END_LISTEN -1
 #define SESSION_INTERACTION "session_interaction"

--- a/src/app/app.c
+++ b/src/app/app.c
@@ -138,13 +138,14 @@ void app_create_gui_session(session *s, app_context_t *app_context) {
   jnx_thread *user_input_thread =
       jnx_thread_create(read_user_input_loop, (void *) gc);
   print_pthread_t(user_input_thread->system_thread);
-  
+
   jnx_char *message;
   while (0 < session_message_read(s, (jnx_uint8 **) &message)) {
     gui_receive_message(gc, message);
   }
   if (QUIT_LOCAL != gc->quit_peer) {
     printf("[DEBUG] Remote session ended.\n");
+    print_pthread_t(pthread_self());
     longjmp(env, QUIT_REMOTE);
   }
   pthread_join(user_input_thread->system_thread, NULL);

--- a/src/app/app.c
+++ b/src/app/app.c
@@ -111,11 +111,10 @@ void unpair_session_from_gui(session *s, void *gui_context) {
 //  s->session_callback = NULL;
 }
 
-void app_create_gui_session(session *s,
-                            session_service *serv) {
+void app_create_gui_session(session *s, session_service *serv) {
   gui_context_t *c = gui_create(s, serv);
   pair_session_with_gui(s, (void *) c);
-  jnx_thread_create_disposable(read_loop, (void *) c);
+  jnx_thread_create_disposable(read_user_input_loop, (void *) c);
   jnx_char *message;
   while (0 < session_message_read(s,(jnx_uint8 **) &message)) {
     gui_receive_message(c, message);
@@ -334,7 +333,8 @@ int link_session_protocol(session *s, linked_session_type lst, void *optarg) {
 }
 
 int unlink_session_protocol(session *s, linked_session_type stype, void *optargs) {
-  // Do nothing
+  app_context_t *context = optargs;
+  auth_comms_stop(context->auth_comms,s);
   return 0;
 }
 

--- a/src/app/app.c
+++ b/src/app/app.c
@@ -28,13 +28,10 @@
 #include "auth_comms.h"
 #include "port_control.h"
 #include <unistd.h>
-#include <setjmp.h>
 
 #define END_LISTEN -1
 #define SESSION_INTERACTION "session_interaction"
 #define RECEIVE_GUID "receive_guid"
-
-jmp_buf env;
 
 static int get_tmp_path(char *path, char *filename) {
   int size = 0;
@@ -144,9 +141,7 @@ void app_create_gui_session(session *s, app_context_t *app_context) {
     gui_receive_message(gc, message);
   }
   if (QUIT_LOCAL != gc->quit_peer) {
-    printf("[DEBUG] Remote session ended.\n");
-    print_pthread_t(pthread_self());
-    longjmp(env, QUIT_REMOTE);
+    gc->quit_peer = QUIT_REMOTE;
   }
   pthread_join(user_input_thread->system_thread, NULL);
 }

--- a/src/app/app.c
+++ b/src/app/app.c
@@ -123,9 +123,6 @@ void unpair_session_from_gui(void *gui_context) {
 }
 
 void pair_session_with_gui(session *s, void *gui_context, void *app_context) {
-  char *guid;
-  jnx_guid_to_string(&s->session_guid, &guid);
-  printf("[DEBUG] Pairing GUI with session '%s'...", guid);
   s->gui_context = gui_context;
   gui_context_t *gc = (gui_context_t *) gui_context;
 

--- a/src/app/app.c
+++ b/src/app/app.c
@@ -102,6 +102,7 @@ int app_accept_or_reject_session(discovery_service *ds,
 }
 
 void unpair_session_from_gui(void *gui_context) {
+  printf("[DEBUG] Unpairing session from GUI...\n");
   gui_context_t *context = (gui_context_t *)gui_context;
   app_context_t *act = (app_context_t *) context->args;
   context->is_active = 0;

--- a/src/app/app.c
+++ b/src/app/app.c
@@ -277,7 +277,8 @@ static void set_up_discovery_service(app_context_t *context) {
   jnx_hashmap *config = context->config;
   char *user_name = (char *) jnx_hash_get(config, "USER_NAME");
   if (NULL == user_name) {
-    user_name = getenv("USER");
+    user_name = malloc(strlen(getenv("USER")) + 1);
+    strcpy(user_name, getenv("USER"));
     JNX_LOG(0, "[WARNING] Using the system user name '%s'.", user_name);
   }
   peerstore *ps = peerstore_init(local_peer_for_user(user_name, peer_update_interval), 0);

--- a/src/app/app.c
+++ b/src/app/app.c
@@ -118,7 +118,6 @@ void app_create_gui_session(session *s,
   jnx_thread_create_disposable(read_loop, (void *) c);
   jnx_char *message;
   while (0 < session_message_read(s,(jnx_uint8 **) &message)) {
-    printf("%s\n", message);
     gui_receive_message(c, message);
   }
   unpair_session_from_gui(s, (void *) c);

--- a/src/app/app.c
+++ b/src/app/app.c
@@ -136,18 +136,15 @@ void app_create_gui_session(session *s, app_context_t *app_context) {
   pair_session_with_gui(s, (void *) gc, (void *) app_context);
   jnx_thread_create_disposable(read_user_input_loop, (void *) gc);
   jnx_char *message;
-  int retval;
-  while (0 < (retval = session_message_read(s, (jnx_uint8 **) &message))) {
+  while (0 < session_message_read(s, (jnx_uint8 **) &message)) {
     gui_receive_message(gc, message);
   }
-  if (retval == 0) {
-    printf("[DEBUG] Mark it zero!\n");
+  if (QUIT_LOCAL != gc->quit_end) {
+    printf("[DEBUG] Remote session ended.\n");
     longjmp(env, 1);
   }
-  else {
-    while (gc->is_active)
-      sleep(1);
-  }
+  while (gc->is_active)
+    sleep(1);
 }
 
 int is_equivalent(char *command, char *expected) {

--- a/src/app/app.c
+++ b/src/app/app.c
@@ -128,12 +128,12 @@ void pair_session_with_gui(session *s, void *gui_context, void *app_context) {
 
 void app_create_gui_session(session *s, app_context_t *app_context) {
   session_service *serv = app_context->session_serv;
-  gui_context_t *c = gui_create(s, serv);
-  pair_session_with_gui(s, (void *) c, (void *) app_context);
-  jnx_thread_create_disposable(read_user_input_loop, (void *) c);
+  gui_context_t *gc = gui_create(s, serv);
+  pair_session_with_gui(s, (void *) gc, (void *) app_context);
+  jnx_thread_create_disposable(read_user_input_loop, (void *) gc);
   jnx_char *message;
   while (0 < session_message_read(s, (jnx_uint8 **) &message)) {
-      gui_receive_message(c, message);
+      gui_receive_message(gc, message);
   }
 }
 

--- a/src/app/app.c
+++ b/src/app/app.c
@@ -116,6 +116,7 @@ void unpair_session_from_gui(void *gui_context) {
   JNXCHECK(r == SESSION_STATE_OKAY);
   JNXCHECK(session_service_session_is_linked(
       context->session_serv, &context->s->session_guid) == 0);
+  printf("[DEBUG] Unlinked successfully.\n");
 }
 
 void pair_session_with_gui(session *s, void *gui_context, void *app_context) {

--- a/src/app/app.c
+++ b/src/app/app.c
@@ -140,6 +140,8 @@ void app_create_gui_session(session *s, app_context_t *app_context) {
   while (0 < session_message_read(s, (jnx_uint8 **) &message)) {
       gui_receive_message(gc, message);
   }
+  while (gc->is_active)
+    sleep(1);
 }
 
 int is_equivalent(char *command, char *expected) {

--- a/src/app/app.c
+++ b/src/app/app.c
@@ -104,12 +104,8 @@ int app_accept_or_reject_session(discovery_service *ds,
 void unpair_session_from_gui(void *gui_context) {
   gui_context_t *context = (gui_context_t *)gui_context;
   app_context_t *act = (app_context_t *) context->args;
-  char *guid;
-  jnx_guid_to_string(&context->s->session_guid, &guid);
-  printf("[DEBUG] Unpairing GUI from session '%s'...\n", guid);
 
   context->is_active = 0;
-  printf("Exiting GUI from accept.\n");
   session_state r = session_service_unlink_sessions(
       act->session_serv,
       E_AM_RECEIVER,
@@ -119,7 +115,6 @@ void unpair_session_from_gui(void *gui_context) {
   JNXCHECK(r == SESSION_STATE_OKAY);
   JNXCHECK(session_service_session_is_linked(
       context->session_serv, &context->s->session_guid) == 0);
-  printf("[DEBUG] Unlinked successfully.\n");
 }
 
 void pair_session_with_gui(session *s, void *gui_context, void *app_context) {
@@ -175,22 +170,25 @@ int code_for_command(char *command) {
 
 int app_code_for_command_with_param(char *command, jnx_size cmd_len, char **oparam) {
   *oparam = NULL;
+  int retval;
   char *raw_cmd = strtok(command, " \n\r\t");
   if (!raw_cmd) {
-    return CMD_HELP;
+    retval = CMD_HELP;
   }
   char *extra_params = strtok(NULL, " \n\r\t");
   if (is_equivalent(raw_cmd, "session")) {
     if (!extra_params) {
       printf("Requires name of peer as argument.\n");
-      return CMD_HELP;
+      retval = CMD_HELP;
     }
     *oparam = malloc(strlen(extra_params) + 1);
     strcpy(*oparam, extra_params);
     return CMD_SESSION;
   } else {
-    return code_for_command(raw_cmd);
+    retval = code_for_command(raw_cmd);
   }
+  free(command);
+  return retval;
 }
 
 void app_prompt() {

--- a/src/app/app.h
+++ b/src/app/app.h
@@ -51,10 +51,9 @@ void app_show_help();
 void app_quit_message();
 int app_code_for_command_with_param(char *command,\
     jnx_size cmd_len, char **oparam);
-void app_create_gui_session(session *s,session_service *serv);
+void app_create_gui_session(session *s, app_context_t *app_context);
 void app_list_active_peers(app_context_t *context);
 peer *app_peer_from_input(app_context_t *context,char *param);
-void app_initiate_handshake(app_context_t *context,session *s);
 int app_accept_or_reject_session(discovery_service *ds,
     jnx_guid *ig, jnx_guid *sg);
 session *app_accept_chat(app_context_t *context);

--- a/src/app/app.h
+++ b/src/app/app.h
@@ -24,6 +24,7 @@
 #include <jnxc_headers/jnxunixsocket.h>
 #include "discovery.h"
 #include "auth_comms.h"
+#include "secure_comms.h"
 #include "session_service.h"
 #define CMDLEN 64
 

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -131,16 +131,7 @@ int run_app(app_context_t *context) {
   }
 }
 
-jmp_buf env;
-
-void sigpipe_handler(int sig) {
-  JNXCHECK(sig == SIGPIPE);
-  longjmp(env, 1);
-}
-
 int main(int argc, char **argv) {
-  signal(SIGPIPE, sigpipe_handler);
-
   jnx_hashmap *config = load_config(argc, argv);
   app_context_t *app_context = app_create_context(config);
   run_app(app_context);

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -56,6 +56,9 @@ int run_app(app_context_t *context) {
     switch (app_code_for_command_with_param(cmd_string, read_bytes, &param)) {
       case CMD_ACCEPT_SESSION:
         osession = app_accept_chat(context);
+        char *guid;
+        jnx_guid_to_string(&osession->session_guid, &guid);
+        printf("[DEBUG] Pairing GUI with session '%s'...", guid);
         app_create_gui_session(osession, context);
 
         session_service_destroy_session(
@@ -99,6 +102,9 @@ int run_app(app_context_t *context) {
           while(!secure_comms_is_socket_linked(s->secure_socket))
             sleep(1);
           printf("Secure socket linked on initiator end.\n");
+          char *guid;
+          jnx_guid_to_string(&s->session_guid, &guid);
+          printf("[DEBUG] Pairing GUI with session '%s'...", guid);
           app_create_gui_session(s, context);
 
           session_service_destroy_session(context->session_serv,

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -128,7 +128,6 @@ int run_app(app_context_t *context) {
         app_show_help();
         break;
     }
-    free(cmd_string);
   }
 }
 

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -56,7 +56,7 @@ int run_app(app_context_t *context) {
     switch (app_code_for_command_with_param(cmd_string, read_bytes, &param)) {
       case CMD_ACCEPT_SESSION:
         osession = app_accept_chat(context);
-        app_create_gui_session(osession, context->session_serv, context);
+        app_create_gui_session(osession, context);
 
         session_service_destroy_session(
             context->session_serv,
@@ -99,7 +99,7 @@ int run_app(app_context_t *context) {
           while(!secure_comms_is_socket_linked(s->secure_socket))
             sleep(1);
           printf("Secure socket linked on initiator end.\n");
-          app_create_gui_session(s, context->session_serv);
+          app_create_gui_session(s, context);
 
           session_service_destroy_session(context->session_serv,
                                           &(*s).session_guid);

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -54,12 +54,9 @@ int run_app(app_context_t *context) {
     jnx_size s = getline(&cmd_string, &read_bytes, stdin);
     char *param = NULL;
     session *osession;
-    char *guid;
     switch (app_code_for_command_with_param(cmd_string, read_bytes, &param)) {
       case CMD_ACCEPT_SESSION:
         osession = app_accept_chat(context);
-        jnx_guid_to_string(&osession->session_guid, &guid);
-        printf("[DEBUG] Pairing GUI with session '%s'...\n", guid);
         app_create_gui_session(osession, context);
 
         session_service_destroy_session(
@@ -103,8 +100,6 @@ int run_app(app_context_t *context) {
           while(!secure_comms_is_socket_linked(s->secure_socket))
             sleep(1);
           printf("Secure socket linked on initiator end.\n");
-          jnx_guid_to_string(&s->session_guid, &guid);
-          printf("[DEBUG] Pairing GUI with session '%s'...\n", guid);
           app_create_gui_session(s, context);
 
           session_service_destroy_session(context->session_serv,

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -61,14 +61,13 @@ int run_app(app_context_t *context) {
         printf("Exiting GUI from accept.\n");
         session_state r = session_service_unlink_sessions(
             context->session_serv,
-            E_AM_INITIATOR,
+            E_AM_RECEIVER,
             NULL,
             &osession->session_guid);
 
         JNXCHECK(r == SESSION_STATE_OKAY);
         JNXCHECK(session_service_session_is_linked(
-            context->session_serv,
-            &osession->session_guid) == 0);
+            context->session_serv, &osession->session_guid) == 0);
         session_service_destroy_session(
             context->session_serv,
             &osession->session_guid);
@@ -140,11 +139,14 @@ int run_app(app_context_t *context) {
       case CMD_QUIT:
         app_quit_message();
         discovery_notify_peers_of_shutdown(context->discovery);
+        app_destroy_context(&context);
         return 0;
+      default:
+        app_show_help();
+        break;
     }
     free(cmd_string);
   }
-  return 0;
 }
 
 int main(int argc, char **argv) {

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -53,12 +53,12 @@ int run_app(app_context_t *context) {
     jnx_size s = getline(&cmd_string, &read_bytes, stdin);
     char *param = NULL;
     session *osession;
+    char *guid;
     switch (app_code_for_command_with_param(cmd_string, read_bytes, &param)) {
       case CMD_ACCEPT_SESSION:
         osession = app_accept_chat(context);
-        char *guid;
         jnx_guid_to_string(&osession->session_guid, &guid);
-        printf("[DEBUG] Pairing GUI with session '%s'...", guid);
+        printf("[DEBUG] Pairing GUI with session '%s'...\n", guid);
         app_create_gui_session(osession, context);
 
         session_service_destroy_session(
@@ -102,9 +102,8 @@ int run_app(app_context_t *context) {
           while(!secure_comms_is_socket_linked(s->secure_socket))
             sleep(1);
           printf("Secure socket linked on initiator end.\n");
-          char *guid;
           jnx_guid_to_string(&s->session_guid, &guid);
-          printf("[DEBUG] Pairing GUI with session '%s'...", guid);
+          printf("[DEBUG] Pairing GUI with session '%s'...\n", guid);
           app_create_gui_session(s, context);
 
           session_service_destroy_session(context->session_serv,

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -20,6 +20,7 @@
 #include "whisper_errors.h"
 #include <jnxc_headers/jnxcheck.h>
 #include "app.h"
+#include <jnxc_headers/jnxguid.h>
 
 jnx_hashmap *load_config(int argc, char **argv) {
   if (argc > 1) {
@@ -79,7 +80,7 @@ int run_app(app_context_t *context) {
 
           peer *local_peer = peerstore_get_local_peer(context->discovery->peers);
           if (strcmp(remote_peer->host_address, local_peer->host_address) == 0) {
-            printf("You cannot t a session with yourself.\n");
+            printf("You cannot create a session with yourself.\n");
             break;
           }
           printf("Found peer.\n");

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -56,7 +56,7 @@ int run_app(app_context_t *context) {
     switch (app_code_for_command_with_param(cmd_string, read_bytes, &param)) {
       case CMD_ACCEPT_SESSION:
         osession = app_accept_chat(context);
-        app_create_gui_session(osession, context->session_serv);
+        app_create_gui_session(osession, context->session_serv, context);
 
         session_service_destroy_session(
             context->session_serv,

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -52,22 +52,12 @@ int run_app(app_context_t *context) {
     jnx_size read_bytes;
     jnx_size s = getline(&cmd_string, &read_bytes, stdin);
     char *param = NULL;
-    jnx_vector *active_peers = NULL;
     session *osession;
     switch (app_code_for_command_with_param(cmd_string, read_bytes, &param)) {
       case CMD_ACCEPT_SESSION:
         osession = app_accept_chat(context);
         app_create_gui_session(osession, context->session_serv);
-        printf("Exiting GUI from accept.\n");
-        session_state r = session_service_unlink_sessions(
-            context->session_serv,
-            E_AM_RECEIVER,
-            NULL,
-            &osession->session_guid);
 
-        JNXCHECK(r == SESSION_STATE_OKAY);
-        JNXCHECK(session_service_session_is_linked(
-            context->session_serv, &osession->session_guid) == 0);
         session_service_destroy_session(
             context->session_serv,
             &osession->session_guid);
@@ -111,14 +101,6 @@ int run_app(app_context_t *context) {
           printf("Secure socket linked on initiator end.\n");
           app_create_gui_session(s, context->session_serv);
 
-          session_state r = session_service_unlink_sessions(context->session_serv,
-                                                            E_AM_INITIATOR,
-                                                            NULL,
-                                                            &(*s).session_guid);
-
-          JNXCHECK(r == SESSION_STATE_OKAY);
-          JNXCHECK(session_service_session_is_linked(context->session_serv,
-                                                     &(*s).session_guid) == 0);
           session_service_destroy_session(context->session_serv,
                                           &(*s).session_guid);
 

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -42,9 +42,6 @@ jnx_hashmap *load_config(int argc, char **argv) {
 }
 
 int run_app(app_context_t *context) {
-  char command[CMDLEN];
-  char *broadcast, *local;
-
   app_intro();
   while (1) {
     app_prompt();
@@ -103,7 +100,7 @@ int run_app(app_context_t *context) {
           app_create_gui_session(s, context);
 
           session_service_destroy_session(context->session_serv,
-                                          &(*s).session_guid);
+                                          &s->session_guid);
 
         } else {
           printf("Session could not be started.\nDid you spell your target%s",

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -17,12 +17,13 @@
  */
 #include <stdlib.h>
 #include <stdio.h>
+#include <setjmp.h>
+#include <signal.h>
+
 #include "whisper_errors.h"
 #include <jnxc_headers/jnxcheck.h>
 #include "app.h"
 #include <jnxc_headers/jnxguid.h>
-#include <setjmp.h>
-#include <signal.h>
 
 jnx_hashmap *load_config(int argc, char **argv) {
   if (argc > 1) {
@@ -133,15 +134,13 @@ int run_app(app_context_t *context) {
 jmp_buf env;
 
 void sigpipe_handler(int sig) {
-  signal(SIGPIPE, SIG_IGN);
-  if (sig == SIGPIPE) {
-    printf("[DEBUG] Received SIGPIPE and handling it.\n");
-  }
+  JNXCHECK(sig == SIGPIPE);
   longjmp(env, 1);
 }
 
 int main(int argc, char **argv) {
   signal(SIGPIPE, sigpipe_handler);
+
   jnx_hashmap *config = load_config(argc, argv);
   app_context_t *app_context = app_create_context(config);
   run_app(app_context);

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -132,12 +132,7 @@ void display_alert_message(gui_context_t *c, char *msg) {
   display_message(c->ui, msg, COL_ALERT);
 }
 
-static int unlink_session_protocol(session *s, void *optargs) {
-
-  return 0;
-}
-
-void *read_loop(void *data) {
+void *read_user_input_loop(void *data) {
   gui_context_t *context = (gui_context_t *) data;
   while (TRUE) {
     char *msg = get_message(context);

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -53,9 +53,13 @@ void display_logo() {
   attroff(COLOR_PAIR(COL_LOGO) | A_BOLD);
   refresh();
 }
-
-gui_context_t *gui_create(
-    session *s, session_service *serv, quit_hint callback) {
+static void missing_callback(void *arg) {
+  printf("You need to set the quit_callback for cleanup in the GUI context.\n");
+  printf("The relevant filds are:\n")
+  printf("[gui_context_t] quit_callback - callback function of type quit_hint\n");
+  printf("[gui_context_t] args - argument of type void* to pass to the quit_callback\n");
+}
+gui_context_t *gui_create(session *s, session_service *serv) {
   gui_context_t *c = malloc(sizeof(gui_context_t));
   ui_t *ui = malloc(sizeof(ui_t));
   initscr();
@@ -75,7 +79,11 @@ gui_context_t *gui_create(
   c->session_serv = serv;
   c->msg = NULL;
   c->is_active = 1;
-  c->quit_callback = callback;
+
+  // These need to be set by the client
+  c->quit_callback = missing_callback;
+  c->args = NULL;
+
   return c;
 }
 
@@ -83,7 +91,7 @@ void gui_destroy(gui_context_t *c) {
   delwin(c->ui->screen);
   delwin(c->ui->prompt);
   endwin();
-  c->quit_callback((void *)c);
+  c->quit_callback(c->args);
 }
 
 char *get_message(gui_context_t *c) {

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -55,7 +55,7 @@ void display_logo() {
 }
 static void missing_callback(void *arg) {
   printf("You need to set the quit_callback for cleanup in the GUI context.\n");
-  printf("The relevant filds are:\n")
+  printf("The relevant filds are:\n");
   printf("[gui_context_t] quit_callback - callback function of type quit_hint\n");
   printf("[gui_context_t] args - argument of type void* to pass to the quit_callback\n");
 }

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -108,6 +108,7 @@ char *get_message(gui_context_t *c) {
     print_pthread_t(pthread_self());
     strcpy(msg, ":q");
     c->quit_peer = QUIT_REMOTE;
+    sleep(5);
   }
   else {
     wmove(c->ui->prompt, 1, 4);

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -150,6 +150,8 @@ void *read_user_input_loop(void *data) {
   while (TRUE) {
     char *msg = get_message(context);
     if (context->quit_hint == QUIT_ON_NEXT_USER_INPUT) {
+      session_message_write(
+          context->s, (jnx_uint8 *) "Dummy write to close the connection.");
       break;
     }
     else if (strcmp(msg, ":q") == 0) {

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -54,7 +54,8 @@ void display_logo() {
   refresh();
 }
 
-gui_context_t *gui_create(session *s, session_service *serv) {
+gui_context_t *gui_create(
+    session *s, session_service *serv, quit_hint callback) {
   gui_context_t *c = malloc(sizeof(gui_context_t));
   ui_t *ui = malloc(sizeof(ui_t));
   initscr();
@@ -74,6 +75,7 @@ gui_context_t *gui_create(session *s, session_service *serv) {
   c->session_serv = serv;
   c->msg = NULL;
   c->is_active = 1;
+  c->quit_callback = callback;
   return c;
 }
 
@@ -81,7 +83,7 @@ void gui_destroy(gui_context_t *c) {
   delwin(c->ui->screen);
   delwin(c->ui->prompt);
   endwin();
-  c->is_active = 0;
+  c->quit_callback((void *)c);
 }
 
 char *get_message(gui_context_t *c) {
@@ -147,6 +149,7 @@ void *read_user_input_loop(void *data) {
     }
   }
   gui_destroy(context);
+  context->quit_callback(context);
   return NULL;
 }
 

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -157,7 +157,7 @@ void *read_user_input_loop(void *data) {
       }
       else {
         display_alert_message(context, msg);
-        display_alert_message(context, "[Session ended. Type :q to quit.]");
+        display_alert_message(context, "\t[Session ended. Type :q to quit.]");
         break;
       }
     }

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -91,7 +91,8 @@ void gui_destroy(gui_context_t *c) {
   delwin(c->ui->screen);
   delwin(c->ui->prompt);
   endwin();
-  c->quit_callback(c->args);
+  c->is_active = 0;
+  c->quit_callback(c);
 }
 
 char *get_message(gui_context_t *c) {

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -80,7 +80,7 @@ gui_context_t *gui_create(session *s, session_service *serv) {
   c->session_serv = serv;
   c->msg = NULL;
   c->is_active = 1;
-  c->quit_peer = QUIT_NONE;
+  c->quit_hint = QUIT_NONE;
 
   // These need to be set by the client
   c->quit_callback = missing_callback;
@@ -149,12 +149,11 @@ void *read_user_input_loop(void *data) {
   gui_context_t *context = (gui_context_t *) data;
   while (TRUE) {
     char *msg = get_message(context);
-    if (context->quit_peer == QUIT_REMOTE) {
+    if (context->quit_hint == QUIT_ON_NEXT_USER_INPUT) {
       break;
     }
     else if (strcmp(msg, ":q") == 0) {
-      if (QUIT_REMOTE != context->quit_peer)
-        context->quit_peer = QUIT_LOCAL;
+      context->quit_hint = QUIT_IMMEDIATELY;
       break;
     }
     else {

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -20,11 +20,14 @@
 #include <string.h>
 #include <jnxc_headers/jnxthread.h>
 #include <pthread.h>
+#include <setjmp.h>
 
 #define COL_LOGO   1
 #define COL_LOCAL  2
 #define COL_REMOTE 3
 #define COL_ALERT  4
+
+extern jmp_buf env;
 
 void init_colours() {
   if (has_colors() == FALSE) {
@@ -100,11 +103,12 @@ void gui_destroy(gui_context_t *c) {
 char *get_message(gui_context_t *c) {
   char *msg = malloc(1024);
   wmove(c->ui->prompt, 1, 4);
-  if (ERR == wgetstr(c->ui->prompt, msg)) {
-    strcpy(msg, ":q");
+  if (setjmp(env) == 0) {
+    wgetstr(c->ui->prompt, msg);
+    show_prompt(c->ui);
   }
   else {
-    show_prompt(c->ui);
+    strcpy(msg, ":q");
   }
   return msg;
 }

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -156,6 +156,8 @@ void *read_user_input_loop(void *data) {
         display_local_message(context, msg);
       }
       else {
+        display_alert_message(context, msg);
+        display_alert_message(context, "[Session ended. Type :q to quit.]");
         break;
       }
     }

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -104,6 +104,7 @@ void gui_destroy(gui_context_t *c) {
 char *get_message(gui_context_t *c) {
   char *msg = malloc(1024);
   if (setjmp(env) == QUIT_REMOTE) {
+    sleep(5);
     print_pthread_t(pthread_self());
     strcpy(msg, ":q");
     c->quit_peer = QUIT_REMOTE;

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -157,7 +157,6 @@ void *read_user_input_loop(void *data) {
     }
   }
   gui_destroy(context);
-  context->quit_callback(context);
   return NULL;
 }
 

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -84,6 +84,7 @@ gui_context_t *gui_create(session *s, session_service *serv) {
   c->session_serv = serv;
   c->msg = NULL;
   c->is_active = 1;
+  c->quit_end = QUIT_NONE;
 
   // These need to be set by the client
   c->quit_callback = missing_callback;
@@ -109,6 +110,7 @@ char *get_message(gui_context_t *c) {
   }
   else {
     strcpy(msg, ":q");
+    c->quit_end = QUIT_REMOTE;
   }
   return msg;
 }
@@ -158,6 +160,8 @@ void *read_user_input_loop(void *data) {
   while (TRUE) {
     char *msg = get_message(context);
     if (strcmp(msg, ":q") == 0) {
+      if (QUIT_REMOTE != context->quit_end)
+        context->quit_end = QUIT_LOCAL;
       break;
     }
     else {

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -155,20 +155,6 @@ void *read_loop(void *data) {
   return NULL;
 }
 
-void *remote_loop(void *data) {
-  gui_context_t *context = (gui_context_t *) data;
-  while (context->s->is_connected) {
-    jnx_char *omessage = NULL;
-    jnx_int read = session_message_read(context->s,(jnx_uint8 **) &omessage);
-
-    if (omessage) {
-      display_remote_message(context, omessage);
-      free(omessage);
-    }
-  }
-  return NULL;
-}
-
 void gui_receive_message(void *gc, jnx_char *message) {
   gui_context_t *c = (gui_context_t *) gc;
   if (!c->is_active) {
@@ -180,10 +166,5 @@ void gui_receive_message(void *gc, jnx_char *message) {
   else {
     display_alert_message(c, message);
   }
-}
-
-void *read_remote_data_bootstrap(void *data) {
-  jnx_thread_create_disposable(remote_loop, data);
-  return NULL;
 }
 

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -155,6 +155,9 @@ void *read_user_input_loop(void *data) {
       if (SESSION_STATE_OKAY == res) {
         display_local_message(context, msg);
       }
+      else {
+        break;
+      }
     }
   }
   gui_destroy(context);

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -30,6 +30,7 @@ typedef struct {
 } ui_t;
 
 typedef void(*quit_hint)(void *);
+typedef void* quit_args;
 
 typedef struct {
   ui_t *ui;
@@ -38,10 +39,11 @@ typedef struct {
   char *msg;
   int is_active;
   quit_hint quit_callback;
+  quit_args args;
 } gui_context_t;
 
 gui_context_t *gui_create(
-    session *s, session_service *serv, quit_hint callback);
+    session *s, session_service *serv);
 void gui_destroy(gui_context_t *c);
 char *get_message(gui_context_t *c);
 void display_local_message(gui_context_t *c, char *msg);

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -42,7 +42,7 @@ void gui_destroy(gui_context_t *c);
 char *get_message(gui_context_t *c);
 void display_local_message(gui_context_t *c, char *msg);
 void display_remote_message(gui_context_t *c, char *msg);
-void *read_loop(void *data);
+void *read_user_input_loop(void *data);
 void gui_receive_message(void *gc, jnx_char *message);
 
 #endif

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -49,8 +49,6 @@ typedef struct {
   quit_args args;
 } gui_context_t;
 
-void print_pthread_t(pthread_t id);
-
 gui_context_t *gui_create(
     session *s, session_service *serv);
 void gui_destroy(gui_context_t *c);

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -34,8 +34,8 @@ typedef void* quit_args;
 
 typedef enum {
   QUIT_NONE,
-  QUIT_LOCAL,
-  QUIT_REMOTE
+  QUIT_IMMEDIATELY,
+  QUIT_ON_NEXT_USER_INPUT
 } quit_enum;
 
 typedef struct {
@@ -44,7 +44,7 @@ typedef struct {
   session *s;
   char *msg;
   int is_active;
-  quit_enum quit_peer;
+  quit_enum quit_hint;
   quit_hint quit_callback;
   quit_args args;
 } gui_context_t;

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -32,12 +32,19 @@ typedef struct {
 typedef void(*quit_hint)(void *);
 typedef void* quit_args;
 
+typedef enum {
+  QUIT_NONE,
+  QUIT_LOCAL,
+  QUIT_REMOTE
+} quit_enum;
+
 typedef struct {
   ui_t *ui;
   session_service *session_serv;
   session *s;
   char *msg;
   int is_active;
+  quit_enum quit_end;
   quit_hint quit_callback;
   quit_args args;
 } gui_context_t;

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -29,15 +29,19 @@ typedef struct {
   int next_line;
 } ui_t;
 
+typedef void(*quit_hint)(void *);
+
 typedef struct {
   ui_t *ui;
   session_service *session_serv;
   session *s;
   char *msg;
   int is_active;
+  quit_hint quit_callback;
 } gui_context_t;
 
-gui_context_t *gui_create(session *s,session_service *service);
+gui_context_t *gui_create(
+    session *s, session_service *serv, quit_hint callback);
 void gui_destroy(gui_context_t *c);
 char *get_message(gui_context_t *c);
 void display_local_message(gui_context_t *c, char *msg);

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -44,10 +44,12 @@ typedef struct {
   session *s;
   char *msg;
   int is_active;
-  quit_enum quit_end;
+  quit_enum quit_peer;
   quit_hint quit_callback;
   quit_args args;
 } gui_context_t;
+
+void print_pthread_t(pthread_t id);
 
 gui_context_t *gui_create(
     session *s, session_service *serv);


### PR DESCRIPTION
Still unresolved, and quite possibly needs changes in whisper-core.

1) Initiating the session to the same peer twice in the same session. I get 'Address already in use' binding error and secure_socket ends up being -1. I have a sneaky feeling it might have something to do with reusing the same secure port both times (seems to fool your port service maybe?) and due to this http://hea-www.harvard.edu/~fine/Tech/addrinuse.html section Strategies for Avoidance > SO_REUSEADDR in second paragraph that starts with 'Oddly, using SO_REUSEADDR can actually lead to more difficult "address already in use" errors...' Can't be sure but it might be worth investigating, maybe never reusing the same port in the same session.

2) Cannot reject the session, the initiator seems to hang. This could possible be me doing something wrong so might need your guidance with this.
